### PR TITLE
Update Navigation.js no-js

### DIFF
--- a/src/js/Navigation/Navigation.js
+++ b/src/js/Navigation/Navigation.js
@@ -16,7 +16,7 @@ class Navigation {
      * 
      */
     removeNoJs() {
-        const listItems = Array.from(this.menu.querySelectorAll('.no-js'))
+        const listItems = Array.from(this.menu.querySelectorAll('#' + this.menuId + ' .no-js'))
         listItems.map(item => item.classList.remove('no-js'))
     }
 


### PR DESCRIPTION
the no-js removal was a bit too specific and causing a conflict in newer versions of beaver builder.  this might not be the permanent fix but it will help with scoping the plugin regardless.